### PR TITLE
Remove usages of Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@ THE SOFTWARE.
 
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>33.1.0-jre</version>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.15.1</version>

--- a/src/main/java/test/ClassLoadingFromJarTester.java
+++ b/src/main/java/test/ClassLoadingFromJarTester.java
@@ -1,7 +1,7 @@
 package test;
 
-import com.google.common.base.Function;
 import hudson.remoting.Callable;
+import java.util.function.Function;
 import org.jenkinsci.remoting.RoleChecker;
 
 /**
@@ -10,12 +10,14 @@ import org.jenkinsci.remoting.RoleChecker;
 public class ClassLoadingFromJarTester implements Callable<Object,Exception>, Function<Function,Void> {
     public Function verifier;
 
+    @Override
     public Object call() throws Exception {
         // verify that the tester is loaded into the correct state
         return verifier.apply(this);
     }
 
     // just so that we can set the delegate without reflection
+    @Override
     public Void apply(Function function) {
         this.verifier = function;
         return null;

--- a/src/main/java/test/Foo.java
+++ b/src/main/java/test/Foo.java
@@ -1,10 +1,9 @@
 package test;
 
-import com.google.common.base.Predicate;
+import static junit.framework.Assert.assertNotNull;
 
 import java.io.Serializable;
-
-import static junit.framework.Assert.*;
+import java.util.function.Predicate;
 
 /**
  * For testing nested objects
@@ -43,7 +42,8 @@ public class Foo implements Predicate<Void>, Serializable {
     /**
      * Verify that the object is still in a good state
      */
-    public boolean apply(Void aVoid) {
+    @Override
+    public boolean test(Void aVoid) {
         one.validate();
         two.validate();
         return true;

--- a/src/test/java/jenkins/Junit4TestsRanTest.java
+++ b/src/test/java/jenkins/Junit4TestsRanTest.java
@@ -1,0 +1,14 @@
+package jenkins;
+
+import org.junit.Test;
+
+public class Junit4TestsRanTest {
+
+    @Test
+    public void anything() {
+        /*
+         * Intentionally blank. We just want a test that runs with JUnit so that buildPlugin() works
+         * in the Jenkinsfile.
+         */
+    }
+}


### PR DESCRIPTION
Remove Guava in favor of Java 8 functionality.

### Testing done

Ran `PrefetchingTest` in Remoting with

```java
diff --git a/src/test/java/hudson/remoting/PrefetchingTest.java b/src/test/java/hudson/remoting/PrefetchingTest.java
index 73c1140c..1fb415b4 100644
--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -1,8 +1,5 @@
 package hudson.remoting;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -13,6 +10,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -239,7 +238,7 @@ public class PrefetchingTest implements Serializable {
             e.value = cl.loadClass("test.Foo").getDeclaredConstructor().newInstance();
             Object r = channel.call(e);
 
-            ((Predicate<Void>) r).apply(null); // this verifies that the object is still in a good state
+            ((Predicate<Void>) r).test(null); // this verifies that the object is still in a good state
         });
     }
 
```